### PR TITLE
Extended jinja.py to make it more useful

### DIFF
--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -6,11 +6,10 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
-from jinja2 import Template, FileSystemLoader, Environment
+from jinja2 import FileSystemLoader, Environment
 
 
 class JinjaDirective(Directive):
-
     has_content = True
     required_arguments = 1
     option_spec = {
@@ -33,7 +32,6 @@ class JinjaDirective(Directive):
         cxt["options"] = {
             "header_char": self.options.get("header_char")
         }
-
         if template_filename:
             if debug_template is not None:
                 print('')
@@ -58,20 +56,18 @@ class JinjaDirective(Directive):
                 print('********** From {} **********'.format(docname))
                 print('\n'.join(self.content))
                 print('********** End Jinja Debug Output: Template Before Processing **********')
-                print('')                
+                print('')
             tpl = Environment(
                       loader=FileSystemLoader(
                           self.app.config.jinja_base, followlinks=True)
                   ).from_string('\n'.join(self.content))
-
         new_content = tpl.render(**cxt)
         if debug_template is not None:
             print('')
             print('********** Begin Jinja Debug Output: Template After Processing **********')
             print(new_content)
             print('********** End Jinja Debug Output: Template After Processing **********')
-            print('')                
-            
+            print('')
         new_content = StringList(new_content.splitlines())
         self.state.nested_parse(new_content, self.content_offset,
                                 node, match_titles=1)

--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -27,7 +27,6 @@ class JinjaDirective(Directive):
         docname = env.docname
         template_filename = self.options.get("file")
         debug_template = self.options.get("debug")
-        print('Debug: %s' % debug_template)
         cxt = self.app.config.jinja_contexts[jinja_context_name]
         cxt["options"] = {
             "header_char": self.options.get("header_char")


### PR DESCRIPTION
Changes:
1) Added debug option because it can be very difficult to figure out why things aren't working
2) Created an Jinja Environment so macros and other files can be included.  Where possible, Jinja will load the template with it's loader.  This works with content and the :file: option
3) Added config option 'jinja_base' as the base for the file loader so relative or absolute paths can be used to load files from within Jinja.  Defaults to same directory as conf.py

Note that in the docs I deal with, everything is contained in the 'source' directory, which doesn't work in the original code when using :file:.  I am pretty sure that the debug option will fail if :file: and :debug: is used together and the document files aren't in "source".  Not sure how to fix that yet.
