### PR TITLE
Support `.. include::` in template.

### DIFF
--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -8,6 +8,7 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 from jinja2 import FileSystemLoader, Environment
+import sphinx.util
 
 
 class JinjaDirective(Directive):
@@ -68,9 +69,9 @@ class JinjaDirective(Directive):
             print(new_content)
             print('********** End Jinja Debug Output: Template After Processing **********')
             print('')
-        new_content = StringList(new_content.splitlines())
-        self.state.nested_parse(new_content, self.content_offset,
-                                node, match_titles=1)
+        new_content = StringList(new_content.splitlines(), source='')
+        sphinx.util.nested_parse_with_titles(
+            self.state, new_content, node)
         return node.children
 
 

--- a/tests/docs/basic/conf.py
+++ b/tests/docs/basic/conf.py
@@ -260,4 +260,5 @@ texinfo_documents = [
 jinja_contexts = {
     'first_ctx': {'topics': {'a': 'b', 'c': 'd'}},
     'second_ctx': {'topics': {'a': 'b', 'c': 'd'}},
+    'null': {},
 }

--- a/tests/docs/basic/index.rst
+++ b/tests/docs/basic/index.rst
@@ -1,6 +1,12 @@
 Welcome to test's documentation!
 ================================
 
+.. jinja:: null
+
+   .. include:: ../../../README.rst
+
+after include
+
 .. jinja:: first_ctx
 
     {% for k, v in topics.items() %}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,8 @@ def test_build_html(app, status, warning):
 def test_build_singlehtml(app, status, warning):
     app.builder.build_all()
     html = (app.outdir / 'index.html').read_text()
+    assert ('<p>A sphinx extension to include jinja based templates based '
+            'documentation into a sphinx doc</p>') in html
     assert '<p>b</p>' in html
     assert '<p>second:a = b</p>' in html
 


### PR DESCRIPTION
Supporting the include directive from with jinja requires passing
`source = ''` to the ViewList constructor (for reasons admittedly not
totally clear to me).

Supporting including contents that include titles requires, well, the
use of sphinx.util.nested_parse_with_titles instead of nested_parse.

See https://groups.google.com/forum/#!topic/sphinx-dev/l4fHrIJfwq4
and http://www.sphinx-doc.org/en/1.7/extdev/markupapi.html#parsing-directive-content-as-rest