### PR TITLE
Allow parallel builds.

### DIFF
--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -80,3 +80,4 @@ def setup(app):
     app.add_directive('jinja', JinjaDirective)
     app.add_config_value('jinja_contexts', {}, 'env')
     app.add_config_value('jinja_base', os.path.abspath('.'), 'env')
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}


### PR DESCRIPTION
Return metadata as in http://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata: there is no reason to prevent parallel builds when using sphinx-jinja.

You may also want to return a version here, I'll let you decide where you want to pull it from (e.g., define `__version__` and return it in `setup`).