### PR TITLE
Don't let header_char modify the default config in-place.

### DIFF
--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -28,7 +28,7 @@ class JinjaDirective(Directive):
         docname = env.docname
         template_filename = self.options.get("file")
         debug_template = self.options.get("debug")
-        cxt = (self.app.config.jinja_contexts[self.arguments[0]]
+        cxt = (self.app.config.jinja_contexts[self.arguments[0]].copy()
                if self.arguments else {})
         cxt["options"] = {
             "header_char": self.options.get("header_char")


### PR DESCRIPTION
1) Avoids "action-at-distance" between directives (setting :header_char:
   on one directive would previously also modify the parsing of
   following directives).
2) Avoids invalidating the sphinx cache (previously, sphinx would
   *always* consider that all files need to be rebuilt because the
   config had changed between the time it's defined in `conf.py` and the
   end of the build).

Last patch I have for now...  A release would be appreciated, thanks!  (Otherwise I can just work off master, either way is fine.)