### PR TITLE
Add debug option to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,9 @@ Available options
       Title
       {{ options.header_char * 5 }}
 
+- ``debug``: print debugging information during sphinx-build. This allows you to see the generated
+  rst before sphinx builds it into another format.
+
 Example of declaration in your RST file:
 
 .. code:: rst

--- a/README.rst
+++ b/README.rst
@@ -38,15 +38,16 @@ Available options
 - ``file``: allow to specify a path to Jinja instead of writing it into the content of the
   directive. Path is relative to the current directory of sphinx-build tool, typically the directory
   where the ``conf.py`` file is located.
+
 - ``header_char``: character to use for the the headers. You can use it in your template to set your
-    own title character:
+  own title character:
 
-    For example:
+  For example:
 
-    .. code:: rst
+  .. code:: rst
 
-        Title
-        {{ options.header_char * 5 }}
+      Title
+      {{ options.header_char * 5 }}
 
 Example of declaration in your RST file:
 
@@ -56,7 +57,7 @@ Example of declaration in your RST file:
          :file: relative/path/to/template.jinja
          :header_char: -
 
-Each element of the `jinja_contexts` dictionary is a context dict for use in your jinja templates.
+Each element of the ``jinja_contexts`` dictionary is a context dict for use in your jinja templates.
 
 
 Running tests


### PR DESCRIPTION
Add the debug option to the README, which was added in commit d01196af45aeeef594271f1d7603f2878b6b331f.

Also fix some of the formatting.