### PR TITLE
Add MIT license file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Antony Lee <anntzer.lee@gmail.com>
 Gaetan Semet <gaetan.semet@intel.com>
+Jonathan Sick <jsick@lsst.org>
 Pierre Tardy <pierre.tardy@intel.com>
 Pierre Tardy <pierre.tardy@renault.com>
 Pierre Tardy <tardyp@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 CHANGES
 =======
 
+* Add MIT license file
+
 1.1.0
 -----
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2018 Pierre Tardy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ summary = includes jinja templates in a documentation
 description-file = README.rst
 home-page = https://github.com/tardyp/sphinx-jinja
 license = MIT
+license-file = LICENSE
 keywords =
     sphinx
     jinja


### PR DESCRIPTION
Thank you for creating `sphinx-jinja`. We've been using at the Rubin Observatory for projects like [pipelines.lsst.io](https://pipelines.lsst.io), and its been tremendously useful.

This PR is simply to add a `LICENSE` file to the Git repository that reflects the metadata already in `setup.cfg`. I've checked, and the LICENSE file will also be part of the distribution to PyPI.

The issue of a license file came up in our effort to redistribute `sphinx-jinja` on conda-forge (https://github.com/conda-forge/staged-recipes/pull/10614), which is intended to give the community of Conda users easier access to `sphinx-jinja`. Having the license file here in the primary repository means that the Conda package can automatically consume the "official" license here (once there is a new release to PyPI, of course).

Thank you again!