### PR TITLE
Add configuration options and refactor debug printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pyc
 .eggs
 dist
+venv
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,24 @@
 language: python
 sudo: false
 
+jobs:
+  include:
+    - os: linux
+      python: 2.7
+      env: TOXENV=py27
+    - os: linux
+      python: 3.6
+      env: TOXENV=py36
+    - os: linux
+      python: 3.7
+      env: TOXENV=py37
+    - os: linux
+      python: 3.8
+      env: TOXENV=py38
+    - os: linux
+      python: 3.9
+      env: TOXENV=py39
+
 install:
   - pip install tox codecov
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,10 @@
 Antony Lee <anntzer.lee@gmail.com>
 Gaetan Semet <gaetan.semet@intel.com>
 Jonathan Sick <jsick@lsst.org>
+Kenyon Ralph <Kenyon.Ralph@NGC.COM>
 Pierre Tardy <pierre.tardy@intel.com>
 Pierre Tardy <pierre.tardy@renault.com>
 Pierre Tardy <tardyp@gmail.com>
+Roger Aiudi <aiudirog@gmail.com>
 Ryan Parman <ryan@ryanparman.com>
 pburdine <pburdine@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,14 @@
 CHANGES
 =======
 
+* Add Environment customization for kwargs, filters, tests, globals, and policies
+* Refactor debug printing and fix urllib import
+* Use debug in tests - currently breaks on 3.7+
+* Add tox environments for 3.6, 3.7, 3.8, and 3.9
+* Add requirements to requirements.txt and setup.py
 * Add MIT license file
+* README.rst: add debug option
+* README.rst: fix formatting
 
 1.1.0
 -----

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* Use jinja_base for debug printing template files
 * Add Environment customization for kwargs, filters, tests, globals, and policies
 * Refactor debug printing and fix urllib import
 * Use debug in tests - currently breaks on 3.7+

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,46 @@ In your sphinx ``conf.py`` file, you can create or load the contexts needed for 
         'first_ctx': {'topics': {'a': 'b', 'c': 'd'}}
     }
 
+You can also customize the jinja ``Environment`` by passing custom kwargs, adding filters, tests, and globals, and setting policies:
+
+.. code:: python
+
+    jinja_env_kwargs = {
+        'lstrip_blocks': True,
+    }
+
+    jinja_filters = {
+        'bold': lambda value: f'**{value}**',
+    }
+
+    jinja_tests = {
+        'instanceof': lambda value, type: isinstance(value, type),
+    }
+
+    jinja_globals = {
+        'list': list,
+    }
+
+    jinja_policies = {
+        'compiler.ascii_str': False,
+    }
+
+Which can then be used in the templates:
+
+.. code:: rst
+
+    Lists
+    -----
+
+    {% for o in objects -%}
+        {%- if o is instanceof list -%}
+            {%- for x in o -%}
+                - {{ x|bold }}
+            {% endfor -%}
+        {%- endif -%}
+    {%- endfor %}
+
+
 Available options
 =================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-
+sphinx
+docutils
+jinja2

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,6 @@ from setuptools import setup
 
 setup(
     setup_requires=['pbr'],
-    pbr=True
+    pbr=True,
+    install_requires=['sphinx', 'docutils', 'jinja2'],
 )

--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -48,10 +48,12 @@ class JinjaDirective(Directive):
         if template_filename:
             if debug_template is not None:
                 reference_uri = directives.uri(template_filename)
-                template_path = url2pathname(reference_uri)
+                template_path = os.path.join(
+                    os.path.abspath(conf.jinja_base),
+                    url2pathname(reference_uri),
+                )
                 encoded_path = template_path.encode(sys.getfilesystemencoding())
-                imagerealpath = os.path.abspath(encoded_path)
-                with codecs.open(imagerealpath, encoding='utf-8') as f:
+                with codecs.open(encoded_path, encoding='utf-8') as f:
                     debug_print(
                         'Template Before Processing',
                         '******* From {} *******\n{}'.format(docname, f.read()),

--- a/tests/docs/basic/conf.py
+++ b/tests/docs/basic/conf.py
@@ -260,4 +260,29 @@ texinfo_documents = [
 jinja_contexts = {
     'first_ctx': {'topics': {'a': 'b', 'c': 'd'}},
     'second_ctx': {'topics': {'a': 'b', 'c': 'd'}},
+    'third_ctx': {'objects': [
+        [1, 2, 3, 4],
+        'skipped_string',
+        ['a', 'b'],
+    ]},
+}
+
+jinja_env_kwargs = {
+    'lstrip_blocks': True,
+}
+
+jinja_filters = {
+    'bold': lambda value: '**{}**'.format(value),
+}
+
+jinja_tests = {
+    'instanceof': lambda value, type: isinstance(value, type),
+}
+
+jinja_globals = {
+    'list': list,
+}
+
+jinja_policies = {
+    'compiler.ascii_str': False,
 }

--- a/tests/docs/basic/index.rst
+++ b/tests/docs/basic/index.rst
@@ -23,3 +23,22 @@ after first context
    :header_char: ~
 
 after second context
+
+first context with debug on
+
+.. jinja:: first_ctx
+    :debug:
+
+    {% for k, v in topics.items() %}
+
+    {{k}}
+    ~~~~~
+    {{v}}
+    {% endfor %}
+
+second context with debug on
+
+.. jinja:: second_ctx
+   :file: tests/docs/basic/jinja_template.jinja
+   :header_char: ~
+   :debug:

--- a/tests/docs/basic/index.rst
+++ b/tests/docs/basic/index.rst
@@ -24,6 +24,22 @@ after first context
 
 after second context
 
+.. jinja:: third_ctx
+    :debug:
+
+    Lists
+    -----
+
+    {% for o in objects -%}
+        {%- if o is instanceof list -%}
+            {%- for x in o -%}
+                - {{ x|bold }}
+            {% endfor -%}
+        {%- endif -%}
+    {%- endfor %}
+
+after third context
+
 first context with debug on
 
 .. jinja:: first_ctx

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,22 @@
 # -*- coding: utf-8 -*-
 
+import os
+import sys
+from pkgutil import walk_packages
+
 from sphinx_testing import with_app
+
+if sys.version_info[:2] > (3, 0):
+    # Make sure that the other sphinxcontrib packages can be loaded
+    import sphinxcontrib.jinja
+    if 'site-packages' not in sphinxcontrib.__path__:
+        sys.path.remove(os.path.dirname(sphinxcontrib.__path__[0]))
+        del sys.modules['sphinxcontrib']
+        for path in filter(lambda p: 'site-packages' in p, sys.path):
+            contrib = os.path.join(path, 'sphinxcontrib')
+            for minfo in walk_packages([contrib], prefix='sphinxcontrib.'):
+                spec = minfo.module_finder.find_spec(minfo.name)
+                spec.loader.load_module(minfo.name)
 
 
 @with_app(buildername='html', srcdir='tests/docs/basic/')

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -47,3 +47,17 @@ def test_build_epub(app, status, warning):
 @with_app(buildername='json', srcdir='tests/docs/basic/')
 def test_build_json(app, status, warning):
     app.builder.build_all()
+
+
+@with_app(buildername='singlehtml', srcdir='tests/docs/basic/')
+def test_customize_env(app, status, warning):
+    app.builder.build_all()
+    html = (app.outdir / 'index.html').read_text()
+    assert '<h2>Lists' in html
+    assert 'skipped_string' not in html
+    for x in [1, 2, 3, 'a', 'b']:
+        # I have no idea why the <p> tags are missing on 2.7...
+        if sys.version_info[:2] < (3, 0):
+            assert '<li><strong>{}</strong></li>'.format(x) in html
+        else:
+            assert '<li><p><strong>{}</strong></p></li>'.format(x) in html

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 ## building sphinx docs in separate virtual environments.  Give it a try!
 
 [tox]
-envlist=py27
+envlist=py27,py36,py37,py38,py39
 
 [testenv]
 deps=


### PR DESCRIPTION
I've been using this library a lot for some documentation and I found myself wanting to customize Jinja a bit more and I ran into some bugs with the debug printing. This PR contains all the changes I made:

- Added configuration options for adding filters, tests, globals, and policies
    - This should also take care of #16
- Added the ability to configure the extra keyword arguments to `Environment`
- Fixed debug printing on 3.7+ where `urllib.url2pathname` was moved to `urllib.request.url2pathname`
- Removed hard coded assumption that templates are in a 'source' folder when debug printing and instead made them relative to `jinja_base`
- Added `:debug:` usage to the tests to make sure it doesn't error anymore
- Added tox and Travis testing for 3.6+