### PR TITLE
Use `app.srcdir` as jinja_base

### DIFF
--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -83,7 +83,7 @@ def setup(app):
     JinjaDirective.app = app
     app.add_directive('jinja', JinjaDirective)
     app.add_config_value('jinja_contexts', {}, 'env')
-    app.add_config_value('jinja_base', os.path.abspath('.'), 'env')
+    app.add_config_value('jinja_base', app.srcdir, 'env')
     app.add_config_value('jinja_env_kwargs', {}, 'env')
     app.add_config_value('jinja_filters', {}, 'env')
     app.add_config_value('jinja_tests', {}, 'env')


### PR DESCRIPTION
Use `app.srcdir` as jinja_base. Without this, sphinx-jinja behaves inconsistently when selecting "separate source and build directories" (-> Makefile is one level above index.rst/conf.py!) on startup like this:

```
$ sphinx-quickstart docs
Welcome to the Sphinx 4.3.2 quickstart utility.
...
You have two options for placing the build directory for Sphinx output.
Either, you use a directory "_build" within the root path, or you separate
"source" and "build" directories within the root path.
> Separate source and build directories (y/n) [n]: y
...
```

If you then enable sphinx-jinja (obviously), create `docs/source/test.rst` and try to use it with both `include` and `jinja` directives:

```
$ ls docs/
build  make.bat  Makefile  source
$ ls docs/source/
conf.py  index.rst  _static  _templates  test.rst
$ echo test > docs/source/test.rst
$ vim docs/source/index.rst  # ... see output below
```

With `index.rst`  being (what you would expect, I would say):

```rst
...

.. include:: test.rst

.. jinja:: 
   :file: test.rst
```

... and finally generate documentation the usual way:

```
$ make -C docs html
```

Without the patch, you'll get a "jinja2.exceptions.TemplateNotFound: test.rst", because `jinja_base` is (falsly, I would argue) `docs/` and not `docs/source/`. As  a workaround without the patch, you can specify `:file: source/test.rst`, which then works (or manually compute the undocumented  `jinja_base` option.