### PR TITLE
Option to have headers behave more like `include`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .eggs
 dist
 venv
+_build/
 .idea

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,9 @@ to
    :file: test.rst
 ```
 
+* Add `header_update_levels` option to let headers behave in the same way as
+  if include via the `include` directive.
+
 
 1.2.1
 -----

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,11 @@ Available options
       Title
       {{ options.header_char * 5 }}
 
+- ``header_update_levels``: If set, a header in the template will appear as the same level as a
+  header of the same style in the source document, equivalent to when you use the ``include``
+  directive. If not set, headers from the template will be in levels below whatever level is active
+  in the source document.
+
 - ``debug``: print debugging information during sphinx-build. This allows you to see the generated
   rst before sphinx builds it into another format.
 

--- a/sphinxcontrib/jinja.py
+++ b/sphinxcontrib/jinja.py
@@ -21,6 +21,7 @@ class JinjaDirective(Directive):
     option_spec = {
         "file": directives.path,
         "header_char": directives.unchanged,
+        "header_update_levels": directives.flag,
         "debug": directives.unchanged,
     }
     app = None
@@ -67,9 +68,14 @@ class JinjaDirective(Directive):
         new_content = tpl.render(**cxt)
         if debug_template is not None:
             debug_print('Template After Processing', new_content)
-        new_content = StringList(new_content.splitlines(), source='')
-        sphinx.util.nested_parse_with_titles(self.state, new_content, node)
-        return node.children
+
+        if "header_update_levels" in self.options:
+            self.state_machine.insert_input(new_content.splitlines(), source='')
+            return []
+        else:
+            new_content = StringList(new_content.splitlines(), source='')
+            sphinx.util.nested_parse_with_titles(self.state, new_content, node)
+            return node.children
 
 
 def debug_print(title, content):

--- a/tests/docs/basic/header_levels.rst
+++ b/tests/docs/basic/header_levels.rst
@@ -1,0 +1,36 @@
+Header level tests
+==================
+
+First, render without the ``header_update_levels`` option:
+
+.. jinja::
+
+   same style, but second level
+   ============================
+
+   Above header is a second-level header, since all headers will be in levels
+   below the active level header of the caller.
+
+   ************************
+   New style is third level
+   ************************
+
+   A new style will go to an even lower level.
+
+Next, try to render with the ``header_update_levels`` option:
+
+.. jinja::
+   :header_update_levels:
+
+   same style, same level
+   ======================
+
+   Because of the ``header_update_levels`` option, the same header style means
+   the same header level (like with the ``include`` directive).
+
+   ************
+   Second level
+   ************
+
+   A level two section (because this is the first time this style occcurs).
+

--- a/tests/docs/basic/index.rst
+++ b/tests/docs/basic/index.rst
@@ -58,3 +58,7 @@ second context with debug on
    :file: jinja_template.jinja
    :header_char: ~
    :debug:
+
+.. toctree::
+
+   header_levels.html

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -56,3 +56,16 @@ def test_customize_env(make_app):
             assert '<li><strong>{}</strong></li>'.format(x) in html
         else:
             assert '<li><p><strong>{}</strong></p></li>'.format(x) in html
+
+
+def test_header_levels(make_app):
+    app = make_app(buildername='html', srcdir=SRCDIR)
+    app.builder.build_all()
+    html = (app.outdir / 'header_levels.html').read_text()
+    print(html)
+
+    assert '<h1>Header level tests' in html
+    assert '<h2>same style, but second level' in html
+    assert '<h3>New style is third level' in html
+    assert '<h1>same style, same level' in html
+    assert '<h2>Second level' in html


### PR DESCRIPTION
Add the `header_update_levels` option to let templates behave like the `include` directive when it comes to headers. This makes it easier to include whole chapters in similar documents via templates, similar to what the `include` directive is often used for.

Assume you have this file that we use as include or template:

```rst
****************
Stars in include
****************

Some text.
```

and using this source document:

```rst
###########
First-level
###########

****************
Second in source
****************

some text

.. include:: test.rst

.. jinja:: first_ctx
   :file: test.rst

.. jinja:: first_ctx
   :file: test.rst
   :header_update_levels:
```

... the header included via `include` will show at the same level as `Second in source`.  In the first jinja template directive, the header (and all other headers) will be in the levels below the active level of the caller, so a level three header in this case. The header in the second jinja template directive will behave the same way as the `include` directive.

See also the docstring for [nested_parse_with_titles](https://github.com/sphinx-doc/sphinx/blob/4.x/sphinx/util/nodes.py#L334), which states  the function is useful for "when the parsed content comes from a completely different context, such as docstrings." The behavior for the option I have adapted here is from the [original include directive](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/directives/misc.py#l197) (yes, docutils appears to be actually using SVN).

PS: I couldn't think of the perfect option name yet -.-. If you have a better suggestion...