### PR TITLE
[fix] pyproject.toml: fix [tool.poetry]packages definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
     "jinja"
 ]
 packages = [
-  { include = "sphinxcontrib" }
+  {include = "sphinxcontrib", from = "."}
 ]
 [tool.poetry.dependencies]
 python = ">=3.6,<4"


### PR DESCRIPTION
The `from` value needs to be set in the package definition[1].

[1] https://python-poetry.org/docs/pyproject/#packages

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>